### PR TITLE
sepolicy_neverallows

### DIFF
--- a/generic/vendor/common/file.te
+++ b/generic/vendor/common/file.te
@@ -105,7 +105,7 @@ type vendor_wifihal_socket, file_type;
 type vendor_pps_socket, file_type;
 
 # imshelper_app file types
-type vendor_imshelper_app_data_file, file_type, data_file_type;
+type vendor_imshelper_app_data_file, app_data_file_type, file_type, data_file_type;
 
 type vendor_imsd_data_file, file_type, data_file_type;
 

--- a/legacy/vendor/common/file.te
+++ b/legacy/vendor/common/file.te
@@ -235,7 +235,7 @@ type qfp-daemon_data_file, file_type, data_file_type;
 type persist_qti_fp_file, file_type, vendor_persist_type;
 
 # imshelper_app file types
-type imshelper_app_data_file, file_type, data_file_type;
+type imshelper_app_data_file, file_type, app_data_file_type, data_file_type;
 
 # RIDL data files
 type RIDL_data_file, file_type, data_file_type;

--- a/legacy/vendor/common/init-qti-ims-sh.te
+++ b/legacy/vendor/common/init-qti-ims-sh.te
@@ -34,3 +34,6 @@ allow init-qti-ims-sh vendor_shell_exec:file rx_file_perms;
 allow init-qti-ims-sh vendor_toolbox_exec:file rx_file_perms;
 
 set_prop(init-qti-ims-sh, qcom_ims_prop)
+
+# for ro.build.product
+get_prop(init-qti-ims-sh, build_prop)


### PR DESCRIPTION
- FAKE/sepolicy_neverallows_intermediates/sepolicy_neverallows )"
device/qcom/sepolicy_vndr/legacy/vendor/common/init-qti-ims-sh.te:39:ERROR 'unknown type exported2_default_prop' at token ';' on line 91679:
allow init-qti-ims-sh exported2_default_prop:file { getattr open read map };

- ETC/sepolicy.recovery_intermediates/sepolicy.tmp /home/deepak/p-404/out/target/product/RMX1921/obj/ETC
/sepolicy.recovery_intermediates/sepolicy )"
device/qcom/sepolicy_vndr/legacy/vendor/common/init_shell.te:128:ERROR 'unknown type exported3_radio_prop' at token ';' on line 98976:
allow qti_init_shell exported3_radio_prop:file { getattr open read map };

- FAKE/sepolicy_neverallows_intermediates/sepolicy_neverallows )"
device/qcom/sepolicy_vndr/legacy/vendor/common/qtidataservices_app.te:35:ERROR 'unknown type exported_radio_prop' at token ';' on line 100838:
